### PR TITLE
chore: 전체 페이지 라우터 및 레이아웃 계층 설계

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,7 @@
 @import 'tailwindcss';
 
 @theme {
-  /* @ 컬러 시스템 정의 예시
-  --color-primary: #3b82f6;
-  --color-primary-hover: #2563eb;
-  --color-secondary: #10b981;
-   */
+    --color-lightGray: '#F8FAFC'
 }
 
 @layer base {

--- a/src/layout/FullContainer.tsx
+++ b/src/layout/FullContainer.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
+const FullContainer =( )=> {
+  return(
+    <div className="container">
+      <Outlet />
+    </div>
+  )
+}
+
+export default FullContainer;

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,0 +1,16 @@
+import Sidebar from './Sidebar';
+import FullContainer from './FullContainer';
+
+const MainLayout = () => {
+    return (
+      <div className="flex flex-row min-h-screen">
+          <Sidebar />
+
+          <main className="flex-1 p-6">
+              <FullContainer />
+          </main>
+      </div>
+    )
+}
+
+export default MainLayout;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,0 +1,9 @@
+const Sidebar =() => {
+  return(
+    <aside className="w-60 min-h-screen bg-gray-400">
+
+    </aside>
+  )
+}
+
+export default Sidebar;

--- a/src/page/AssignEditPage.tsx
+++ b/src/page/AssignEditPage.tsx
@@ -1,0 +1,7 @@
+const AssignEditPage =() => {
+  return(
+    <div>과제 수정/생성 페이지</div>
+  )
+}
+
+export default AssignEditPage;

--- a/src/page/AssignListPage.tsx
+++ b/src/page/AssignListPage.tsx
@@ -1,0 +1,7 @@
+const AssignListPage =() => {
+  return(
+    <div>과제 확인 페이지</div>
+  )
+}
+
+export default AssignListPage;

--- a/src/page/DashBoardPage.tsx
+++ b/src/page/DashBoardPage.tsx
@@ -1,0 +1,8 @@
+const DashBoardPage = () => {
+  return(
+    <div>전체 지원자 통계 페이지</div>
+    )
+
+}
+
+export default DashBoardPage;

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -1,10 +1,19 @@
 import { useRoutes } from "react-router-dom";
+import MainLayout from '../layout/MainLayout';
+import DashBoardPage from '../page/DashBoardPage';
+import AssignListPage from '../page/AssignListPage';
+import AssignEditPage from '../page/AssignEditPage';
+
 
 const MainRoutes = () => {
   const routes = useRoutes([
     {
-      path: "/",
-      element: <div>Welcome to Code Gambit!</div>
+      path: "/", element: <MainLayout />,
+      children: [
+        { path: '/dashboard', element: <DashBoardPage />},
+        { path: '/assginlist', element: <AssignListPage />},
+        { path: '/assignedit', element: <AssignEditPage />},
+      ]
     },
   ]);
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,3 @@
+export const COLOR = {
+  lightGray : '#F8FAFC'
+}


### PR DESCRIPTION
### 변경사항
- 앱 라우터 정의 및 기본 페이지 설계
- MainLayout -> Sidebar -> FullContainer (찐 화면) 
- 기본 라우터(/) 일때 어느 페이지 보여줄지는 모르겠어서 일단 놔둠 (아마 dashboard?)

### 화면 이미지
<img width="849" height="442" alt="{1804DB69-B45C-4D33-B77B-5FDB6758BC70}" src="https://github.com/user-attachments/assets/175d26b6-9879-4235-885b-acf01f6602b8" />
